### PR TITLE
Rename DependencyID to PluggableID

### DIFF
--- a/THGSupervisor/Pluggable.swift
+++ b/THGSupervisor/Pluggable.swift
@@ -18,12 +18,12 @@ objc : extern MyPluginClass * __nullable pluginForBundle(NSString * __nonnull ap
 
 */
 
-public typealias DependencyID = String
+public typealias PluggableID = String
 
 @objc
 public protocol Pluggable {
-    var identifier: String { get }
-    var dependencies: [DependencyID]? { get }
+    var identifier: PluggableID { get }
+    var dependencies: [PluggableID]? { get }
 
     init?(containerBundleID: String?)
 
@@ -32,7 +32,7 @@ public protocol Pluggable {
 }
 
 public extension Pluggable {
-    func dependsOn(dependencyID: DependencyID) -> Bool {
+    func dependsOn(dependencyID: PluggableID) -> Bool {
         if let deps = dependencies {
             return deps.contains(dependencyID)
         }

--- a/THGSupervisor/Pluggable.swift
+++ b/THGSupervisor/Pluggable.swift
@@ -68,7 +68,10 @@ public extension Pluggable {
 
 @objc
 public protocol PluggableFeature: Pluggable {
-    
+
+    /// Launch Handling
+    optional func application(supervisor: ApplicationSupervisor, application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool
+
     /**
     URL Handling
     */

--- a/THGSupervisor/Pluggable.swift
+++ b/THGSupervisor/Pluggable.swift
@@ -22,13 +22,24 @@ public typealias PluggableID = String
 
 @objc
 public protocol Pluggable {
-    var identifier: PluggableID { get }
+    /// The unique identifier for this plugin
+    /// e.g. com.mycompany.myapp.mainui
+    static var identifier: PluggableID { get }
+
+    /// A list of ```PluggableID``` that this ```Pluggable``` relies on
     var dependencies: [PluggableID]? { get }
 
     init?(containerBundleID: String?)
 
     // Provides the default route to this plugin or feature.
     func startup(supervisor: Supervisor) -> Route?
+}
+
+public extension Pluggable {
+    var identifier: PluggableID { get {
+        return Self.identifier
+    }
+    }
 }
 
 public extension Pluggable {
@@ -42,7 +53,7 @@ public extension Pluggable {
     func pluginDescription() -> String {
         var result = ""
         
-        result += "\(identifier)\n"
+        result += "\(Self.identifier)\n"
         
         if let deps = dependencies {
             for i in 0..<deps.count {

--- a/THGSupervisor/Supervisor.swift
+++ b/THGSupervisor/Supervisor.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+public typealias callPluginClosure = (plugin: Pluggable) -> Void
+
 @objc
 public class Supervisor: UIResponder {
     
@@ -71,7 +73,19 @@ public class Supervisor: UIResponder {
         
         return nil
     }
-    
+
+    public func callLoadedPlugins(closure: callPluginClosure) {
+        // identify the plugins we will actually load.
+        loadedPlugins = validateProposedPlugins(proposedPlugins)
+
+        for i in 0..<loadedPlugins.count {
+            let plugin = loadedPlugins[i]
+
+            closure(plugin: plugin)
+        }
+    }
+
+
     private func startPlugin(plugin: Pluggable) {
         if !pluginStarted(plugin.identifier) {
             print("starting: \(plugin.identifier)")

--- a/THGSupervisor/Supervisor.swift
+++ b/THGSupervisor/Supervisor.swift
@@ -43,19 +43,19 @@ public class Supervisor: UIResponder {
         }
     }
     
-    public func pluginLoaded(dependencyID: DependencyID) -> Bool {
+    public func pluginLoaded(dependencyID: PluggableID) -> Bool {
         return loadedPlugins.contains({ (item) -> Bool in
             return (item.identifier == dependencyID)
         })
     }
     
-    public func pluginStarted(dependencyID: DependencyID) -> Bool {
+    public func pluginStarted(dependencyID: PluggableID) -> Bool {
         return startedPlugins.contains({ (item) -> Bool in
             return (item.identifier == dependencyID)
         })
     }
     
-    private func pluginByID(id: DependencyID) -> Pluggable? {
+    private func pluginByID(id: PluggableID) -> Pluggable? {
         let found = loadedPlugins.filter { (plugin) -> Bool in
             if plugin.identifier == id {
                 return true

--- a/THGSupervisor/Supervisor.swift
+++ b/THGSupervisor/Supervisor.swift
@@ -107,7 +107,7 @@ public class Supervisor: UIResponder {
     }
     
     private func validateProposedPlugins(proposedPlugins: [Pluggable]) -> [Pluggable] {
-        var acceptedPlugins = [Pluggable]()
+        let acceptedPlugins = NSMutableSet()
         
         for i in 0..<proposedPlugins.count {
             print("checking proposal: \(proposedPlugins[i].identifier).")
@@ -122,7 +122,7 @@ public class Supervisor: UIResponder {
                     // the dependency is present, validate it.
                     if present {
                         hasDeps = true
-                        acceptedPlugins.append(proposedPlugins[i])
+                        acceptedPlugins.addObject(proposedPlugins[i])
                     } else {
                         print("ERROR: proposed plugin \(item) is missing dependency \(item).")
                     }
@@ -130,13 +130,14 @@ public class Supervisor: UIResponder {
             } else {
                 // it doesn't have any dependencies, so it's validated.
                 hasDeps = false
-                acceptedPlugins.append(proposedPlugins[i])
+                acceptedPlugins.addObject(proposedPlugins[i])
             }
             let subtext = hasDeps ? "(dependencies present)" : "(no dependencies required)"
             print("validating proposal: \(proposedPlugins[i].identifier) \(subtext)")
         }
-        
-        return acceptedPlugins
+
+        let results = acceptedPlugins.allObjects
+        return results as! [Pluggable]
     }
     
     private var proposedPlugins = [Pluggable]()


### PR DESCRIPTION
Reference plugins via PluggableID. Dependencies are on plugins with identifier:PluggableID
