### PR TITLE
refactor sharedInstance

### DIFF
--- a/ELMaestro.xcodeproj/xcshareddata/xcschemes/ELMaestro.xcscheme
+++ b/ELMaestro.xcodeproj/xcshareddata/xcschemes/ELMaestro.xcscheme
@@ -28,7 +28,26 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CA20797D1BB323B0005353D9"
+               BuildableName = "ELMaestroTests.xctest"
+               BlueprintName = "ELMaestroTests"
+               ReferencedContainer = "container:ELMaestro.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CA2079721BB323B0005353D9"
+            BuildableName = "ELMaestro.framework"
+            BlueprintName = "ELMaestro"
+            ReferencedContainer = "container:ELMaestro.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/ELMaestro/PluggableFeature.swift
+++ b/ELMaestro/PluggableFeature.swift
@@ -65,6 +65,10 @@ public protocol PluggableFeature: Pluggable {
 
     optional func application(application: UIApplication, handleActionWithIdentifier identifier: String?, forRemoteNotification userInfo: [NSObject : AnyObject], withResponseInfo responseInfo: [NSObject : AnyObject], completionHandler: () -> Void)
     
+    // Continuity
+    // application:continueUserActivity:restorationHandler:
+    optional func application(application: UIApplication, continueUserActivity userActivity: NSUserActivity, restorationHandler: ([AnyObject]?) -> Void) -> Bool
+    
     /**
      Application events for background event handling
      */

--- a/ELMaestroTests/ELMaestroTests.swift
+++ b/ELMaestroTests/ELMaestroTests.swift
@@ -39,17 +39,46 @@ class ELMaestroTests: XCTestCase {
     }
     
     func testBasicLoading() {
-        let supervisor = ApplicationSupervisor.sharedInstance
+        let testPluginID = "com.walmartlabs.testplugin"
+        let testObjcPluginID = "com.walmartlabs.testObjcFramework"
+
+        let supervisor = ApplicationSupervisor()
         
         supervisor.loadPlugin(testFramework.pluginClass())
         supervisor.loadPlugin(testObjcFramework.pluginClass())
         
         supervisor.startup()
         
-        XCTAssertTrue(supervisor.pluginLoaded("com.walmartlabs.testplugin"))
-        XCTAssertTrue(supervisor.pluginLoaded("com.walmartlabs.testObjcFramework"))
+        XCTAssertTrue(supervisor.pluginLoaded(testPluginID))
+        XCTAssertTrue(supervisor.pluginLoaded(testObjcPluginID))
 
-        XCTAssertTrue(supervisor.pluginStarted("com.walmartlabs.testplugin"))
-        XCTAssertTrue(supervisor.pluginStarted("com.walmartlabs.testObjcFramework"))
+        XCTAssertTrue(supervisor.pluginStarted(testPluginID))
+        XCTAssertTrue(supervisor.pluginStarted(testObjcPluginID))
+    }
+    
+    func testContinuity() {
+        let testPluginID = "com.walmartlabs.testplugin"
+        let testObjcPluginID = "com.walmartlabs.testObjcFramework"
+
+        let supervisor = ApplicationSupervisor()
+        
+        supervisor.loadPlugin(testFramework.pluginClass())
+        supervisor.loadPlugin(testObjcFramework.pluginClass())
+
+        supervisor.startup()
+        
+        XCTAssertTrue(supervisor.pluginLoaded(testPluginID))
+        XCTAssertTrue(supervisor.pluginLoaded(testObjcPluginID))
+        
+        XCTAssertTrue(supervisor.pluginStarted(testPluginID))
+
+        let api = supervisor.pluginAPIForID(testPluginID) as! TestPluginAPI
+
+        let application = UIApplication.sharedApplication()
+        let userActivity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        let handled = supervisor.application(application, continueUserActivity: userActivity, restorationHandler:{ arr in })
+        
+        XCTAssertTrue(handled, "Expected a plugin to handle continuity")
+        XCTAssertTrue(api.continuityType == NSUserActivityTypeBrowsingWeb, "Expected NSUserActivityTypeBrowsingWeb")
     }
 }

--- a/ELMaestroTests/TestPlugins/testFramework/testFramework.xcodeproj/project.pbxproj
+++ b/ELMaestroTests/TestPlugins/testFramework/testFramework.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		20D6211E1D30186200E86FB0 /* testPluginAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D6211D1D30186200E86FB0 /* testPluginAPI.swift */; };
 		CA61C9731C504ADD00742949 /* ELRouter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA61C9721C504ADD00742949 /* ELRouter.framework */; };
 		CA6822CE1BB4679200562A62 /* ELMaestro.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA6822CD1BB4679200562A62 /* ELMaestro.framework */; };
 		CA85A8F21B31F83A0000FEEF /* testFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = CA85A8F11B31F83A0000FEEF /* testFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -27,6 +28,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		20D6211D1D30186200E86FB0 /* testPluginAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = testPluginAPI.swift; sourceTree = "<group>"; };
 		CA61C9721C504ADD00742949 /* ELRouter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ELRouter.framework; path = "../../../../ELRouter/build/Debug-iphoneos/ELRouter.framework"; sourceTree = "<group>"; };
 		CA6822CD1BB4679200562A62 /* ELMaestro.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ELMaestro.framework; path = "../../../build/Debug-iphoneos/ELMaestro.framework"; sourceTree = "<group>"; };
 		CA85A8EC1B31F83A0000FEEF /* testFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = testFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -86,6 +88,7 @@
 				CA85A8F11B31F83A0000FEEF /* testFramework.h */,
 				CA85A9441B31F8C90000FEEF /* testEntry.swift */,
 				CA85A9461B31F8FF0000FEEF /* testPlugin.swift */,
+				20D6211D1D30186200E86FB0 /* testPluginAPI.swift */,
 				CA85A8EF1B31F83A0000FEEF /* Supporting Files */,
 			);
 			path = testFramework;
@@ -227,6 +230,7 @@
 			files = (
 				CA85A9471B31F8FF0000FEEF /* testPlugin.swift in Sources */,
 				CA85A9451B31F8C90000FEEF /* testEntry.swift in Sources */,
+				20D6211E1D30186200E86FB0 /* testPluginAPI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ELMaestroTests/TestPlugins/testFramework/testFramework/testPlugin.swift
+++ b/ELMaestroTests/TestPlugins/testFramework/testFramework/testPlugin.swift
@@ -22,6 +22,8 @@ public class TestPlugin: NSObject, PluggableFeature {
         return ["com.walmartlabs.testObjcFramework"]
     }
     
+    private let _pluginAPI = TestPluginAPI()
+    
     required public init?(containerBundleID: String?) {
         super.init()
     }
@@ -31,16 +33,18 @@ public class TestPlugin: NSObject, PluggableFeature {
         return nil
     }
     
-    /**
-    URL Handling
-    */
+    // MARK: API
+    
+    public func pluginAPI() -> AnyObject? {
+        return _pluginAPI
+    }
+    
+    // MARK: URL Handling
     public func routeForURL(url: NSURL) -> Route? {
         return nil
     }
     
-    /**
-    Notification handling
-    */
+    // MARK: Notification Handling
     public func routeForLocalNotification(notification: UILocalNotification) -> Route? {
         return nil
     }
@@ -49,14 +53,17 @@ public class TestPlugin: NSObject, PluggableFeature {
         return nil
     }
     
-    /**
-    Application lifecycle events
-    */
+    // MARK: Application lifecycle events
     public func applicationWillTerminate() {
         
     }
     
     public func applicationDidReceiveMemoryWarning() {
         
+    }
+    
+    public func application(application: UIApplication, continueUserActivity userActivity: NSUserActivity, restorationHandler: ([AnyObject]?) -> Void) -> Bool {
+        _pluginAPI.continuityType = userActivity.activityType
+        return true
     }
 }

--- a/ELMaestroTests/TestPlugins/testFramework/testFramework/testPluginAPI.swift
+++ b/ELMaestroTests/TestPlugins/testFramework/testFramework/testPluginAPI.swift
@@ -1,0 +1,14 @@
+//
+//  testPluginAPI.swift
+//  testFramework
+//
+//  Created by Steve Riggins on 7/8/16.
+//  Copyright © 2016 StereoLab. All rights reserved.
+//
+
+import Foundation
+
+
+public class TestPluginAPI : NSObject {    
+    public var continuityType: String = ""
+}


### PR DESCRIPTION
Refactored ApplicationSupervisor.sharedInstance to return the shared application’s app delegate. This allows the ApplicationSupervisor to be instantiated directly for unit testing, and also couples the API to UIApplication, as ApplicationSupervisor is meant to be the app delegate.

Added support for Continuity by extending the PluggableFeature protocol and dispatching to plugins that implement the API.

Added a unit test to test the dispatch mechanism on ApplicationSupervisor. Added a testPluginAPI to capture test results for later inspection by a unit test.

Added the unit test target to the ELMaestro scheme’s test phase.
