### PR TITLE
satisfy `window` property requirement of `UIApplicationDelegate`

### DIFF
--- a/ELMaestro/ApplicationDelegateProxy.swift
+++ b/ELMaestro/ApplicationDelegateProxy.swift
@@ -12,6 +12,15 @@ import Foundation
 open class ApplicationDelegateProxy: UIResponder, UIApplicationDelegate {
     public internal(set) var supervisor = ApplicationSupervisor.sharedInstance
     
+    public var window: UIWindow? {
+        get {
+            return supervisor.window
+        }
+        set {
+            supervisor.window = newValue
+        }
+    }
+    
     override public init() {
         super.init()
     }


### PR DESCRIPTION
Fixes a crash from ReactNative when hitting ESC to return from error window.