### PR TITLE
UserNotification cleanup

### DIFF
--- a/ELMaestro.xcodeproj/project.pbxproj
+++ b/ELMaestro.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 		3E8CA3D520E580CE00CBDA69 /* PluggableFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FF6D281CEE69C300F843B6 /* PluggableFeature.swift */; };
 		3E8CA3D620E580CE00CBDA69 /* Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB863341CA1C2380051F45A /* Module.swift */; };
 		3E8CA3DA20E580CE00CBDA69 /* ELMaestro.h in Headers */ = {isa = PBXBuildFile; fileRef = CA2079781BB323B0005353D9 /* ELMaestro.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		88AA341C2286060E009CF97A /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88AA341B2286060E009CF97A /* UserNotifications.framework */; };
 		CA2079791BB323B0005353D9 /* ELMaestro.h in Headers */ = {isa = PBXBuildFile; fileRef = CA2079781BB323B0005353D9 /* ELMaestro.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA20797F1BB323B0005353D9 /* ELMaestro.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA2079731BB323B0005353D9 /* ELMaestro.framework */; };
 		CA2079861BB323B0005353D9 /* ELMaestroTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2079851BB323B0005353D9 /* ELMaestroTests.swift */; };
@@ -56,7 +55,6 @@
 		199CFEC51F9909DA004D8FB3 /* TestPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestPlugin.swift; sourceTree = "<group>"; };
 		199CFEC71F9909FB004D8FB3 /* TestPluginAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestPluginAPI.swift; sourceTree = "<group>"; };
 		3E8CA3E020E580CE00CBDA69 /* ELMaestro.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ELMaestro.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		88AA341B2286060E009CF97A /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
 		CA2079731BB323B0005353D9 /* ELMaestro.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ELMaestro.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA2079771BB323B0005353D9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CA2079781BB323B0005353D9 /* ELMaestro.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ELMaestro.h; sourceTree = "<group>"; };
@@ -81,7 +79,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				88AA341C2286060E009CF97A /* UserNotifications.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -99,7 +96,6 @@
 		88AA341A2286060E009CF97A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				88AA341B2286060E009CF97A /* UserNotifications.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/ELMaestro/ApplicationDelegateProxy.swift
+++ b/ELMaestro/ApplicationDelegateProxy.swift
@@ -112,17 +112,13 @@ open class ApplicationDelegateProxy: UIResponder, UIApplicationDelegate {
             feature.application?(application, handleActionWithIdentifier: identifier, forRemoteNotification: userInfo, completionHandler: completionHandler)
         }
     }
-    
 
-    
-    @available(iOS 9.0, *)
     open func application(_ application: UIApplication, handleActionWithIdentifier identifier: String?, forRemoteNotification userInfo: [AnyHashable: Any], withResponseInfo responseInfo: [AnyHashable: Any], completionHandler: @escaping () -> Void) {
         for feature in supervisor.startedFeaturePlugins {
             feature.application?(application, handleActionWithIdentifier: identifier, forRemoteNotification: userInfo, withResponseInfo: responseInfo, completionHandler: completionHandler)
         }
     }
-    
-    @available(iOS 9.0, *)
+
     open func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
         for feature in supervisor.startedFeaturePlugins {
             let handled = feature.applicationPerformActionForShortcutItem?(shortcutItem, completionHandler: completionHandler)

--- a/ELMaestro/PluggableFeature.swift
+++ b/ELMaestro/PluggableFeature.swift
@@ -7,7 +7,6 @@
 //
 import Foundation
 import UIKit
-import UserNotifications
 
 @objc
 public protocol PluggableFeature: Pluggable {
@@ -44,8 +43,7 @@ public protocol PluggableFeature: Pluggable {
     @objc optional func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void)
     @objc optional func application(_ application: UIApplication, handleActionWithIdentifier identifier: String?, forRemoteNotification userInfo: [AnyHashable: Any], completionHandler: @escaping () -> Void)
     
-    @objc @available(iOS 9.0, *)
-    optional func application(_ application: UIApplication, handleActionWithIdentifier identifier: String?, forRemoteNotification userInfo: [AnyHashable : Any], withResponseInfo responseInfo: [AnyHashable: Any], completionHandler: @escaping () -> Void)
+    @objc optional func application(_ application: UIApplication, handleActionWithIdentifier identifier: String?, forRemoteNotification userInfo: [AnyHashable : Any], withResponseInfo responseInfo: [AnyHashable: Any], completionHandler: @escaping () -> Void)
     
     // Continuity
     
@@ -60,8 +58,7 @@ public protocol PluggableFeature: Pluggable {
      Application events for watchkit handling -- is this needed?
      */
     @objc optional func applicationHandleWatchKitExtensionRequest(_ userInfo: [AnyHashable: Any]?, reply: (([AnyHashable: Any]?) -> Void)!)
-    
-    @objc @available(iOS 9.0, *)
+
     /**
      Application events for handling force touch springboard shortcuts
      
@@ -70,5 +67,5 @@ public protocol PluggableFeature: Pluggable {
      
      - returns: Whether the action was performed by the plugin
      */
-    optional func applicationPerformActionForShortcutItem(_ shortcutItem: UIApplicationShortcutItem, completionHandler: (Bool) -> Void) -> Bool
+    @objc optional func applicationPerformActionForShortcutItem(_ shortcutItem: UIApplicationShortcutItem, completionHandler: (Bool) -> Void) -> Bool
 }

--- a/ELMaestroTests/ApplicationDelegateProxyTests.swift
+++ b/ELMaestroTests/ApplicationDelegateProxyTests.swift
@@ -154,10 +154,7 @@ class ApplicationDelegateProxyTests: XCTestCase {
     }
     
     func test_handleActionWithIdentifierForRemoteNotificationWithResponseInfo_shouldCallPlugin() {
-        guard #available(iOS 9.0, *) else {
-            return
-        }
-        
+
         let proxy = proxyForTesting()
         let supervisor = supervisorForTesting(proxy: proxy)
         let api = supervisor.pluginAPI(forIdentifier: testPluginID) as! TestPluginAPI
@@ -171,9 +168,6 @@ class ApplicationDelegateProxyTests: XCTestCase {
     }
     
     func test_performActionForShorcutItem_shouldCallPlugin() {
-        guard #available(iOS 9.0, *) else {
-            return
-        }
         
         let proxy = proxyForTesting()
         let supervisor = supervisorForTesting(proxy: proxy)

--- a/ELMaestroTests/TestPlugin.swift
+++ b/ELMaestroTests/TestPlugin.swift
@@ -92,7 +92,6 @@ final class TestPlugin: NSObject, PluggableFeature {
         api.handleActionWithIdentifierForRemoteNotificationCalled?.fulfill()
     }
     
-    @available(iOS 9.0, *)
     func applicationPerformActionForShortcutItem(_ shortcutItem: UIApplicationShortcutItem, completionHandler: (Bool) -> Void) -> Bool {
         api.performActionForShortcutItemCalled?.fulfill()
         return true


### PR DESCRIPTION
After moving the deployment target to iOS 10, we don't need the checks for iOS 9. This PR addresses following 

*Remove check for iOS 9 
*Remove UserNotification references