### PR TITLE
add missing app delegate methods

### DIFF
--- a/ELMaestro/ApplicationDelegateProxy.swift
+++ b/ELMaestro/ApplicationDelegateProxy.swift
@@ -185,4 +185,15 @@ open class ApplicationDelegateProxy: UIResponder, UIApplicationDelegate {
         }
         return false // Not handled by any feature plugin
     }
+
+    open func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+        for feature in supervisor.startedFeaturePlugins {
+            let handled = feature.application?(app, open: url, options: options)
+            if let featureHandled = handled, featureHandled {
+                return true
+            }
+        }
+
+        return false
+    }
 }

--- a/ELMaestro/ApplicationDelegateProxy.swift
+++ b/ELMaestro/ApplicationDelegateProxy.swift
@@ -24,6 +24,23 @@ open class ApplicationDelegateProxy: UIResponder, UIApplicationDelegate {
     override public init() {
         super.init()
     }
+
+    open func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        var result = true
+
+        if supervisor.startedPlugins.count == 0 {
+            assertionFailure("Perform plugin startup before calling application:willFinishLaunchingWithOptions:")
+        } else {
+            for feature in supervisor.startedFeaturePlugins {
+                // coalesce our return values together
+                if let value = feature.application?(application, willFinishLaunchingWithOptions: launchOptions) {
+                    result = result || value
+                }
+            }
+        }
+
+        return result
+    }
     
     open func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         var result = true

--- a/ELMaestro/PluggableFeature.swift
+++ b/ELMaestro/PluggableFeature.swift
@@ -18,10 +18,9 @@ public protocol PluggableFeature: Pluggable {
      let pluginAPI = supervisor.pluginAPI(forIdentifier: "com.myorg.mymodule") as? MyPluginAPI
      */
     @objc optional func pluginAPI() -> AnyObject?
-    
-    /**
-     After all plugins have been started, the system will dispatch this to your plugin.
-     */
+
+    @objc optional func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]?) -> Bool
+
     @objc optional func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable: Any]?) -> Bool
     
     /**

--- a/ELMaestro/PluggableFeature.swift
+++ b/ELMaestro/PluggableFeature.swift
@@ -75,4 +75,6 @@ public protocol PluggableFeature: Pluggable {
      - returns: Whether the action was performed by the plugin
      */
     optional func applicationPerformActionForShortcutItem(_ shortcutItem: UIApplicationShortcutItem, completionHandler: (Bool) -> Void) -> Bool
+
+    @objc optional func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any]) -> Bool
 }

--- a/ELMaestroTests/ApplicationDelegateProxyTests.swift
+++ b/ELMaestroTests/ApplicationDelegateProxyTests.swift
@@ -249,6 +249,18 @@ class ApplicationDelegateProxyTests: XCTestCase {
         
         waitForExpectations(timeout: 2.0, handler: nil)
     }
+
+    func test_applicationOpenOptions_shouldCallPlugin() {
+        let proxy = proxyForTesting()
+        let supervisor = supervisorForTesting(proxy: proxy)
+        let api = supervisor.pluginAPI(forIdentifier: testPluginID) as! TestPluginAPI
+        api.applicationOpenOptionsCalled = expectation(description: "Should call `application:open:options:`")
+        let url = URL(string: "https://www.walmart.com/")!
+
+        let _ = proxy.application(UIApplication.shared, open: url, options: [UIApplicationOpenURLOptionsKey : Any]())
+
+        waitForExpectations(timeout: 2.0, handler: nil)
+    }
 }
 
 enum RemoteNotificationError: Error {

--- a/ELMaestroTests/ApplicationDelegateProxyTests.swift
+++ b/ELMaestroTests/ApplicationDelegateProxyTests.swift
@@ -27,6 +27,17 @@ class ApplicationDelegateProxyTests: XCTestCase {
     }
     
     // MARK: - Tests
+
+    func test_applicationWillFinishLaunchingWithOptions_shouldCallPlugins() {
+        let proxy = proxyForTesting()
+        let supervisor = supervisorForTesting(proxy: proxy)
+        let api = supervisor.pluginAPI(forIdentifier: testPluginID) as! TestPluginAPI
+        api.applicationWillFinishLaunchingWithOptionsCalled = expectation(description: "Should call `applicationwillFinishLaunchingWithOptions`")
+
+        let _ =  proxy.application(UIApplication.shared, willFinishLaunchingWithOptions: nil)
+
+        waitForExpectations(timeout: 2.0, handler: nil)
+    }
     
     func test_applicationDidFinishLaunchingWithOptions_shouldCallPlugins() {
         let proxy = proxyForTesting()

--- a/ELMaestroTests/TestPlugin.swift
+++ b/ELMaestroTests/TestPlugin.swift
@@ -37,6 +37,12 @@ final class TestPlugin: NSObject, PluggableFeature {
     }
     
     // MARK: Application  lifecycle events
+
+    func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]?) -> Bool {
+        api.applicationWillFinishLaunchingWithOptionsCalled?.fulfill()
+        return true
+    }
+
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable : Any]?) -> Bool {
         api.applicationDidFinishLaunchingWithOptionsCalled?.fulfill()

--- a/ELMaestroTests/TestPlugin.swift
+++ b/ELMaestroTests/TestPlugin.swift
@@ -119,4 +119,9 @@ final class TestPlugin: NSObject, PluggableFeature {
         api.performActionForShortcutItemCalled?.fulfill()
         return true
     }
+
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any]) -> Bool {
+        api.applicationOpenOptionsCalled?.fulfill()
+        return true
+    }
 }

--- a/ELMaestroTests/TestPluginAPI.swift
+++ b/ELMaestroTests/TestPluginAPI.swift
@@ -11,7 +11,8 @@ import XCTest
 
 final class TestPluginAPI : NSObject {
     var continuityType: String = ""
-    
+
+    var applicationWillFinishLaunchingWithOptionsCalled: XCTestExpectation?
     var applicationDidFinishLaunchingWithOptionsCalled: XCTestExpectation?
     var applicationWillResignActiveCalled: XCTestExpectation?
     var applicationDidEnterBackgroundCalled: XCTestExpectation?

--- a/ELMaestroTests/TestPluginAPI.swift
+++ b/ELMaestroTests/TestPluginAPI.swift
@@ -30,4 +30,6 @@ final class TestPluginAPI : NSObject {
     var handleActionWithIdentifierWithResponseInfoCalled: XCTestExpectation?
     var performActionForShortcutItemCalled: XCTestExpectation?
     var didReceiveLocalNotificationCalled: XCTestExpectation?
+    var applicationOpenOptionsCalled: XCTestExpectation?
+
 }


### PR DESCRIPTION
Add support for `application:open:options` and  `application:willFinishLaunchingWithOptions`

Needed to add support to v5 for Grocery. I'll have a follow up PR for v6.