### PR TITLE
GPMNETE-5260 - Change the access level from open to public, deeplinking never calls the open function.

### DIFF
--- a/ELMaestro/ApplicationDelegateProxy.swift
+++ b/ELMaestro/ApplicationDelegateProxy.swift
@@ -159,7 +159,7 @@ open class ApplicationDelegateProxy: UIResponder, UIApplicationDelegate {
         return false // Not handled by any feature plugin
     }
 
-    open func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         for feature in supervisor.startedFeaturePlugins {
             let handled = feature.application?(app, open: url, options: options)
             if let featureHandled = handled, featureHandled {


### PR DESCRIPTION
Delegate to open a deeplink was never getting called, we had to change the access level from open to public for it to get called.